### PR TITLE
Adds Environment Values

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+HAVEIBEENPWNED_API_KEY=some-api-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,6 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
 .venv
 env/
 venv/
@@ -103,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# .idea
+.idea

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,3 @@ logouturl = https://www.linkedin.com/m/logout
 viewbyemail = https://linkedin.com/sales/gmail/profile/viewByEmail/
 sessionkey = ""
 sessionpassword = ""
-
-[plugin.haveibeenpwned]
-api_key = ""
-

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'numpy',
         'simplejson',
         'tqdm',
-        'selenium'
+        'selenium',
+        'python-dotenv'
     ]
 )

--- a/src/skiptracer/plugins/base.py
+++ b/src/skiptracer/plugins/base.py
@@ -11,6 +11,7 @@ import json
 # monkey patch socket to use only IPv4
 import socket
 import pkg_resources
+from dotenv import dotenv_values
 
 try:
     import __builtin__ as bi
@@ -53,6 +54,7 @@ class PageGrabber:
         """
         Initialize defaults as needed
         """
+        self.env = dotenv_values()
         self.info_dict = {}
         self.info_list = []
         self.ua = random_line()

--- a/src/skiptracer/plugins/haveibeenpwned/__init__.py
+++ b/src/skiptracer/plugins/haveibeenpwned/__init__.py
@@ -41,7 +41,11 @@ class HaveIBeenPwwnedGrabber(PageGrabber):
                 email)
 
             scraper = cfscrape.create_scraper()
-            self.source = scraper.get(url).content
+            header = {
+                'user-agent': self.ua,
+                'hibp-api-key': self.env['HAVEIBEENPWNED_API_KEY']
+            }
+            self.source = scraper.get(url, header=header).content
             self.source = str(
                 self.source).replace(
                 "true",


### PR DESCRIPTION
Request was to add an environment file that housed the API key for `haveibeenpwnd`.

To do this, we added the package `python-dovenv` with a `.env` file to the project. The `.env` file has the HIBP API key in it, but the value must be replaced by a key of the user (directly into the `.env` file). More environment-type values will be added as necessary.

Remove the API key info from the `setup.cfg` file, since it will now be included via the environment file.

We use the `dotenv_values()` function to prevent polution of API keys and other future values in the host machine's global environment value namespace in, say, bash.